### PR TITLE
Modify link for s2e-core

### DIFF
--- a/General/HowToCompileWithUbuntuInDocker.md
+++ b/General/HowToCompileWithUbuntuInDocker.md
@@ -33,13 +33,13 @@
 ## 3. A Sequence of environment setting
 ### 3.1. Working directory setting
 - Create `work` directory as a working directory.
-- Clone [S2E_CORE_OSS](https://gitlab.com/ut_issl/s2e/s2e_core_oss) in the `work` directory.
+- Clone [s2e-core](https://github.com/ut-issl/s2e-core) in the `work` directory.
 - Add the `work` directory in the `file sharing` directory of Docker.  
   **Note**: This setting does not exist in the latest Docker and WSL2 environments in Windows, so it is not necessary.
 
 ### 3.2. Make Docker image and container
 - Launch `git bush` (for windows users) or `terminal` (for Mac users)
-- Move `/s2e_core_oss/scripts/Docker_Ubuntu` directory
+- Move `/s2e-core/scripts/Docker_Ubuntu` directory
 - Edit `Dockerfile` or `setup_docker.sh` when you want to change the directory name, the user name of the container, and other settings.
 - Execute `./setup_docker.sh build` to make images
 - Check created image (`issl` (and `ubuntu`))  
@@ -82,7 +82,7 @@ Host issl-1
 - Users can execute most of the script files with `git bush` or `terminal` in the outside of the container, but users should execute `scripts/Common/download_nrlmsise00_src_and_table.sh` inside the container to use the same compiler.
 - Click `Terminal > New terminal` in the menu bar of VS Code
 - Select `bash` terminal at the bottom window
-- execute `./s2e_core_oss/scripts/Common/download_nrlmsise00_src_and_table.sh`
+- execute `./s2e-core/scripts/Common/download_nrlmsise00_src_and_table.sh`
 - See `ExtLibraries` to confirm the NRLMSISE library is generated.
  
 
@@ -94,14 +94,14 @@ Host issl-1
   - CMake Tools  
 **Note** : You need to reload VS Code after installing new extensions
 - Edit setting of `CMake Tools` in `issl-1`  
-  `Cmake Build Directory: ${workspaceFolder}/s2e_core_oss/build/Debug`
-- After `CMake` and `CMake Tools` are installed, VS Code requires you to configure the build environment with `CMakeList.txt`. Please select `yes`. But there is no `CMakeList.txt` file in the `work` directory, and VS Code requires you to locate `CMakeList.txt`, so please select the `CMakeList.txt` file in `s2e_core_oss` directory.
+  `Cmake Build Directory: ${workspaceFolder}/s2e-core/build/Debug`
+- After `CMake` and `CMake Tools` are installed, VS Code requires you to configure the build environment with `CMakeList.txt`. Please select `yes`. But there is no `CMakeList.txt` file in the `work` directory, and VS Code requires you to locate `CMakeList.txt`, so please select the `CMakeList.txt` file in `s2e-core` directory.
   - This setting is written in `.vscode/settings.json`
   - You can directly edit the `settings.json` as follows
     ```json
     {
-      "cmake.sourceDirectory": "${workspaceFolder}/s2e_core_oss",
-      "cmake.buildDirectory": "${workspaceFolder}/s2e_core_oss/build/Debug"
+      "cmake.sourceDirectory": "${workspaceFolder}/s2e-core",
+      "cmake.buildDirectory": "${workspaceFolder}/s2e-core/build/Debug"
     }
     ```
 - Select `GCC 9.3.0` as a kit (compiler) 
@@ -118,9 +118,9 @@ Host issl-1
   `.vscode/launch.json` will be created.
 - Edit as follows
   ```json
-  "program": "${workspaceFolder}/s2e_core_oss/build/Debug/S2E",
+  "program": "${workspaceFolder}/s2e-core/build/Debug/S2E",
 
-  "cwd": "${workspaceFolder}/s2e_core_oss/build/Debug",
+  "cwd": "${workspaceFolder}/s2e-core/build/Debug",
   ```
 - Select `Run > Start Debugging` again
 - Check `data/log` directory to confirm log file output

--- a/General/HowToDownloadNRLMSISE00library.md
+++ b/General/HowToDownloadNRLMSISE00library.md
@@ -6,12 +6,12 @@
 - How to use NRLMSISE00 is written in the [Specification of Atmosphere model](../Specifications/Environment/Spec_Atmosphere.md).
 
 ## 2. How to set up NRLMSISE00 for S2E  
-1. In any environment, run `s2e_core_oss/scripts/Common/download_nrlmsise00_src_and_table.sh`
+1. In any environment, run `s2e-core/scripts/Common/download_nrlmsise00_src_and_table.sh`
    + Source codes of NRLMISE00 and `SpaceWeather.txt` will be downloaded, and `libnrlmsise00.a` will be made for Linux and OSX.
      + Users have to compile the codes using the same compiler with S2E. After these codes are downloaded, you can directly compile them by using makefile in the `ExtLibraries\nrlmsise00\src`.
    + If you use Windows, a bash terminal for Windows (e.g. Git bash, WSL, MSYS) is needed to run this script, and you need to run an additional script. Proceed to Step 2.
 
-2. For Windows Visual Studio users, run `s2e_core_oss/scripts/VisualStudio/make_nrlmsise00_VS32bit.bat` after the process 1.
+2. For Windows Visual Studio users, run `s2e-core/scripts/VisualStudio/make_nrlmsise00_VS32bit.bat` after the process 1.
    + VS command prompt will be launched, then run `scripts/VisualStudio/make_libnrlmsise.bat` in VS command prompt.
    + `libnrlmise.lib`, which is the library for Windows Visual Studio will be made.
    + At the end of the procedure, you may see "指定されたバッチ ラベルが見つかりません - END". If there is `libnrlmsise00.lib` in the right place and all the files are in the right place, you may ignore this message.
@@ -27,5 +27,5 @@
   |      |  └─libnrlmsise00.lib
   │      └─src
   |         └─nrlmsise-00.h
-  └─s2e_core  
+  └─s2e-core  
 </pre>  

--- a/General/HowToDwnloadCSPCElibrary.md
+++ b/General/HowToDwnloadCSPCElibrary.md
@@ -5,7 +5,7 @@
 - [CSPICE](https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/index.html) is the C language version of SPICE and mandatory library for S2E to get planet information.
 
 ## 2. How to set up CSPICE Library for S2E
-**Note**: Users can use the script file to automatically set up the following process in the `s2e_core_oss/script` directory. If the script does not work, please see the following process.
+**Note**: Users can use the script file to automatically set up the following process in the `s2e-core/script` directory. If the script does not work, please see the following process.
 
 - Make directories as follow
 <pre>   
@@ -15,7 +15,7 @@
   │      │  └─lib  
   │      ├─generic_kernels  
   │      └─include  
-  └─s2e_core  
+  └─s2e-core  
 </pre>  
   - xxx is depends on your compile environment
     - `xxx = msvs` for Microsoft Visual Studio
@@ -48,5 +48,5 @@
         │      └─planets  
         │  │      └─de430.bsp  
   </pre>
-**Note:** When you change the directory or file name, you should modify `S2E_CORE/CMakeLists` and `PlanetSelect.ini`
+**Note:** When you change the directory or file name, you should modify `s2e-core/CMakeLists` and `PlanetSelect.ini`
 

--- a/Specifications/Component/Abstract/Spec_ComponentBase.md
+++ b/Specifications/Component/Abstract/Spec_ComponentBase.md
@@ -12,7 +12,7 @@
 
 3. How to use
   - Inherit this class by the user's component class.
-  - The `RWModel` in `S2E_CORE_OSS` is useful as a usage example of the `FastUpdate`.
+  - The `RWModel` in `S2E_CORE` is useful as a usage example of the `FastUpdate`.
 
 ## 2. Explanation of Algorithm
 1. Constructor

--- a/Specifications/Component/Abstract/Spec_SensorBase.md
+++ b/Specifications/Component/Abstract/Spec_SensorBase.md
@@ -15,7 +15,7 @@
 
 3. How to use
    - Inherit this class by your sensor class.
-   - The `GYRO` and `MagSensor` in `S2E_CORE_OSS` are useful as usage examples.
+   - The `GYRO` and `MagSensor` in `S2E_CORE` are useful as usage examples.
 
 ## 2. Explanation of Algorithm
 1. Constructor

--- a/Specifications/Component/Mission/Spec_Telescope_en.md
+++ b/Specifications/Component/Mission/Spec_Telescope_en.md
@@ -34,7 +34,7 @@
     - Set the parameters in `Telescope.ini`
     - Create instance by using initialization function `InitTelescope`
       + Each telescope is numbered as "Telescope1,…"
-    - To use `HipparcosCatalogue` data, `hip_main.csv` is necessary. `s2e_core_oss/scripts/download_HIPcatalogue.sh` is the script to download it. Run the following code using Git bash in `s2e_core_oss/scripts/`:
+    - To use `HipparcosCatalogue` data, `hip_main.csv` is necessary. `s2e-core/scripts/download_HIPcatalogue.sh` is the script to download it. Run the following code using Git bash in `s2e-core/scripts/`:
     ```
     bash download_HIPcatalogue.sh 
     ```

--- a/Specifications/Component/Mission/Spec_Telescope_ja.md
+++ b/Specifications/Component/Mission/Spec_Telescope_ja.md
@@ -28,7 +28,7 @@
     - Telescope.iniで定数を入力する．
     - 初期化関数 `InitTelescope` を利用し，インスタンスを生成．
         + Telescope1,…のように，個々の望遠鏡に番号が振ってある．
-    - `HipparcosCatalogue` のデータを利用するために，`hip_main.csv` のダウンロードを済ませる必要がある．このためのスクリプトとして `s2e_core_oss/scripts/download_HIPcatalogue.sh`を用意した．Git Bashなどを利用して，このスクリプトがあるディレクトリで以下を実行することで，必要なcsvファイルをダウンロードすることができる．
+    - `HipparcosCatalogue` のデータを利用するために，`hip_main.csv` のダウンロードを済ませる必要がある．このためのスクリプトとして `s2e-core/scripts/download_HIPcatalogue.sh`を用意した．Git Bashなどを利用して，このスクリプトがあるディレクトリで以下を実行することで，必要なcsvファイルをダウンロードすることができる．
     ```
     bash download_HIPcatalogue.sh 
     ``` 

--- a/Specifications/Component/Power/Spec_PCU.md
+++ b/Specifications/Component/Power/Spec_PCU.md
@@ -7,7 +7,7 @@
    - Main file: `PCU.cpp, .h`
    - Related file: `PowerPort.cpp, .h`
 3. How to use
-   - **Example**: The `SampleComponents` in the `S2E_CORE_OSS/Simulation/Spacecraft/SampleSpacecraft` is useful to know how to use this class.
+   - **Example**: The `SampleComponents` in the `s2e-core/Simulation/Spacecraft/SampleSpacecraft` is useful to know how to use this class.
    - Users can make their original `PCU` class by inheriting this base class.
    - Users need to override the `MainRoutine`, `GetLogHeader`, and `GetLogValue` functions to define the behavior of their PCUs. 
 ## 2. Explanation of Algorithm

--- a/Specifications/Dynamics/Spec_RelativeOrbit.md
+++ b/Specifications/Dynamics/Spec_RelativeOrbit.md
@@ -25,7 +25,7 @@
 3. How to use
    
    - Relative orbit propagation is available only when multiple satellites are simulated.
-        + The sample case in S2E_CORE_OSS simulates a single satellite. For an example of simulating multiple satellites, please refer to the [tutorial](../../Tutorials/HowToSimulateMultipleSatellites.md). 
+        + The sample case in S2E_CORE simulates a single satellite. For an example of simulating multiple satellites, please refer to the [tutorial](../../Tutorials/HowToSimulateMultipleSatellites.md). 
    - Confirm the instance of `RelativeInformation` is the member of each satellite.
    - Set up the configuration of the `[ORBIT]` section in the `Sat.ini`.
         + Set `propagate_mode =2` to use the relative orbit propagation

--- a/Specifications/Environment/Spec_HipparcosCatalogue_en.md
+++ b/Specifications/Environment/Spec_HipparcosCatalogue_en.md
@@ -20,7 +20,7 @@
        * This is the original data of the Hipparcos catalogue. It is in the `ExtLibraries` directory. This data is sorted in of the visual magnitude, not in the order of HIP ID.
 
   3. How to download `hip_main.csv`
-     + `s2e_core_oss/scripts/download_HIPcatalogue.sh` is the script to download it. Run the following code using Git bash in `s2e_core_oss/scripts/`．
+     + `s2e-core/scripts/download_HIPcatalogue.sh` is the script to download it. Run the following code using Git bash in `s2e-core/scripts/`．
        * **NOTE for Mac OS users: Run the following script not from the Mac terminal but the Ubuntu terminal in Docker.** (Because the specification of `sed` is different between Mac and Linux, the file cannot be generated correctly. Reference: <https://qiita.com/catfist/items/1156ae0c7875f61417ee>) 
       ```
        bash download_HIPcatalogue.sh 

--- a/Specifications/Environment/Spec_HipparcosCatalogue_ja.md
+++ b/Specifications/Environment/Spec_HipparcosCatalogue_ja.md
@@ -16,9 +16,9 @@
         + `Environment.ini`
             * 初期化ファイル
         + `hip_main.csv`
-            * ヒッパルコス星表の元データ． `S2E_CORE_OSS` 外の `ExtLibralies`  に保存される．使用しやすいように，HIP ID順ではなく，視等級の小さい順にソートされている．
+            * ヒッパルコス星表の元データ． `s2e-core` 外の `ExtLibralies`  に保存される．使用しやすいように，HIP ID順ではなく，視等級の小さい順にソートされている．
     3. 外部ライブラリのダウンロードに関して
-        + まずは`hip_main.csv` のダウンロードを済ませる必要がある．このためのスクリプトとして `s2e_core_oss/scripts/download_HIPcatalogue.sh`を用意した．Git Bashなどを利用して，このスクリプトがあるディレクトリで以下を実行することで，必要なcsvファイルをダウンロードすることができる．
+        + まずは`hip_main.csv` のダウンロードを済ませる必要がある．このためのスクリプトとして `s2e-core/scripts/download_HIPcatalogue.sh`を用意した．Git Bashなどを利用して，このスクリプトがあるディレクトリで以下を実行することで，必要なcsvファイルをダウンロードすることができる．
             * Macユーザーは，Mac標準のターミナルからではなく，Docker内のUbuntuのターミナルから実行する必要がある．（ `sed` の仕様がMacとLinuxで違うので，正しいcsvファイルを生成することができないため．参考：<https://qiita.com/catfist/items/1156ae0c7875f61417ee>）
     ```
     bash download_HIPcatalogue.sh 

--- a/Specifications/Interface/Spec_PowerPort.md
+++ b/Specifications/Interface/Spec_PowerPort.md
@@ -8,7 +8,7 @@
    - Main files: `PowerPort.cpp, .h`
    - Referenced files: `ComponentBase.cpp, .h` and `PCU.cpp, .h`
 3. How to use
-   - **Example**: The `SampleComponents` in the `S2E_CORE_OSS/Simulation/Spacecraft/SampleSpacecraft` is helpful to know how to use the feature.
+   - **Example**: The `SampleComponents` in the `s2e-core/Simulation/Spacecraft/SampleSpacecraft` is helpful to know how to use the feature.
    - Make a component class that inherits the `ComponentBase` class.
      - The `ComponentBase` class has the `PowerPort` class as a member and controls the component's action according to the electrical power switches.
    - Make an instance of `PCU` and connect the power port.

--- a/Tutorials/GettingStarted.md
+++ b/Tutorials/GettingStarted.md
@@ -5,8 +5,8 @@
 - This tutorial explains how to use the S2E simulator without any source code modification.   
 - Users can start this tutorial just after users clone the [s2e-core](https://github.com/ut-issl/s2e-core) repository. 
 - The supported version of this document
-  - s2e-core: the latest `develop` branch
-
+  - s2e-core: [v4.0](https://github.com/ut-issl/s2e-core/releases/tag/v4.0)
+  
 ## 2. Environment
 - This tutorial supports an execution environment with Visual Studio 2019 on a Windows PC.  
 - However, the basic features of S2E are executable for other environments with a small modification of the sequence. 

--- a/Tutorials/GettingStarted.md
+++ b/Tutorials/GettingStarted.md
@@ -3,9 +3,9 @@
 ## 1.  Overview
 
 - This tutorial explains how to use the S2E simulator without any source code modification.   
-- Users can start this tutorial just after users clone the [S2E_CORE_OSS](https://gitlab.com/ut_issl/s2e/s2e_core_oss) repository. 
+- Users can start this tutorial just after users clone the [s2e-core](https://github.com/ut-issl/s2e-core) repository. 
 - The supported version of this document
-  - S2E_CORE_OSS: the latest `develop` branch
+  - s2e-core: the latest `develop` branch
 
 ## 2. Environment
 - This tutorial supports an execution environment with Visual Studio 2019 on a Windows PC.  
@@ -14,7 +14,7 @@
 - The author hopes someone will write a new *Getting Started tutorial* for these environments.
 
 ## 3. Clone & Compile
-1. Clone  [S2E_CORE_OSS](https://gitlab.com/ut_issl/s2e/s2e_core_oss).  
+1. Clone [s2e-core](https://github.com/ut-issl/s2e-core).  
 2. Read `README.md` to check the overview of S2E.
 3. Execute `./scripts/VisualStudio/dowload_cspice_VS32bit.bat` to set up CSPICE library.
    - **Note:** The script is not completely automatic. Users need to input several simple words.  
@@ -22,7 +22,7 @@
 4. Execute `./scripts/Common/download_nrlmsise00_src_and_table.sh` to download the atmosphere model table.
    - If you do not use Windows Visual Studio, or the script does not work well in your environment, please see  [How to download and make NRLMSISE00 Library](../General/HowToDownloadNRLMSISE00library.md) and download the NRLMSISE00 files by yourself.
 4. Execute `./scripts/VisualStudio/make_nrlmsise00_VS32bit.bat` to generate library files for the atmosphere model.
-4. Build and execute the S2E_CORE_OSS by referring [How to compile with Visual Studio](../General/HowToCompileWithVisualStudio.md)  
+4. Build and execute the S2E_CORE by referring [How to compile with Visual Studio](../General/HowToCompileWithVisualStudio.md)  
 
 ## 4. Check log output
 

--- a/Tutorials/HowToAddComponents.md
+++ b/Tutorials/HowToAddComponents.md
@@ -6,7 +6,7 @@
 - This tutorial explains how to add components to your scenario.
 - A similar procedure is available for other components in the `S2E_CORE`.
 - The Supported version of this document
-  - S2E_CORE_OSS: [c3ba](https://gitlab.com/ut_issl/s2e/s2e_core_oss/-/commit/c3ba6d93418998b91efc0a8ca57ff63e350d2636)
+  - s2e-core: [v4.0](https://github.com/ut-issl/s2e-core/releases/tag/v4.0)
 
 ## 2. Add a Gyro sensor
 

--- a/Tutorials/HowToAddControlAlgorithms.md
+++ b/Tutorials/HowToAddControlAlgorithms.md
@@ -1,10 +1,10 @@
 # How To Add Control Algorithms
 
 ## 1.  Overview
-- In the [How To Make New Components](./Tutorials/HowToMakeNewComponents.md) tutorial, we have newly made components emulating codes in [S2E_CORE_OSS](https://gitlab.com/ut_issl/s2e/s2e_core_oss) and adding the new components into our simulation scenario.
+- In the [How To Make New Components](./Tutorials/HowToMakeNewComponents.md) tutorial, we have newly made components emulating codes in [s2e-core](https://github.com/ut-issl/s2e-core) and adding the new components into our simulation scenario.
 - Now we can simulate the behavior of spacecraft **free motion** and emulate the behavior of sensors and actuators. 
 - This tutorial explains how to add a **Control Algorithm** into the simulation scenario. 
-- For a practical satellite project, we should implement the control algorithm as actual flight software like [C2A](https://gitlab.com/ut_issl/c2a/c2a_core_oss) into the S2E. However, using actual flight software is usually overdoing for use cases as research, the initial phase of satellite projects.
+- For a practical satellite project, we should implement the control algorithm as actual flight software like [C2A](https://github.com/ut-issl/c2a-core) into the S2E. However, using actual flight software is usually overdoing for use cases as research, the initial phase of satellite projects.
 - So, we introduce the following three methods, and users can choose a suitable method.
   - Direct: Directly control physical quantity without sensors, actuators, and their noises
     - For theoretical researches and preliminary analysis for satellite projects
@@ -13,7 +13,7 @@
   - FlightSW: Control using sensors and actuators with flight S/W framework
     - For actual satellite projects
 - The Supported version of this document
-  - S2E_CORE_OSS: [c3ba](https://gitlab.com/ut_issl/s2e/s2e_core_oss/-/commit/c3ba6d93418998b91efc0a8ca57ff63e350d2636)
+  - s2e-core: [v4.0](https://github.com/ut-issl/s2e-core/releases/tag/v4.0)
 
 ## 2. Direct method
 - This chapter introduces the simplest way to add a control algorithm without sensors and actuators.

--- a/Tutorials/HowToMakeNewComponents.md
+++ b/Tutorials/HowToMakeNewComponents.md
@@ -4,9 +4,9 @@
 
 - In the [How To Add Components](./Tutorials/HowToAddComponents.md) tutorial, we have added existing components to the simulation scenario.
 - This tutorial explains how to make a new component into the S2E_USER directory.
-- **Note**: You can move the source files for the new component into the [S2E_CORE_OSS](https://gitlab.com/ut_issl/s2e/s2e_core_oss) repository if the component is useful for all S2E users.
+- **Note**: You can move the source files for the new component into the [s2e-core](https://github.com/ut-issl/s2e-core) repository if the component is useful for all S2E users.
 - The Supported version of this document
-  - S2E_CORE_OSS: [c3ba](https://gitlab.com/ut_issl/s2e/s2e_core_oss/-/commit/c3ba6d93418998b91efc0a8ca57ff63e350d2636)
+  - s2e-core: [v4.0](https://github.com/ut-issl/s2e-core/releases/tag/v4.0)
 
 ## 2. Overview of S2E/Components
 

--- a/Tutorials/HowToMakeNewSimulationScenario.md
+++ b/Tutorials/HowToMakeNewSimulationScenario.md
@@ -3,7 +3,7 @@
 ## 1.  Overview
 
 - In the [Getting Started](./Tutorials/GettingStarted.md) tutorial, we can directly build and execute S2E_CORE_OSS, but for **source code sharing** and practical usage of S2E, we **strongly recommend managing S2E_CORE_OSS and S2E_USER repository separately**.
-  - [S2E_CORE_OSS](https://gitlab.com/ut_issl/s2e/s2e_core_oss) repository is shared with other users. Most of the source files are in this repository. The codes are used as a library by the S2E_USER repository.
+  - [s2e-core](https://github.com/ut-issl/s2e-core) repository is shared with other users. Most of the source files are in this repository. The codes are used as a library by the S2E_USER repository.
   - S2E_USER repository is an independent repository  for **each spacecraft project or research project**. This repository includes the following parts:
     - Source codes for `simulation scenario` and the `main`
     - Source codes for `components` if you have components, which strongly depends on your project.
@@ -11,15 +11,15 @@
     - Compile setting files as [CMake files](https://cmake.org/), [Visual Studio Solution files](https://visualstudio.microsoft.com/downloads/), and others. 
 - This tutorial explains an example of how to make S2E_USER repository and execute it.   
 - The supported version of this document
-  - S2E_CORE_OSS: [c3ba](https://gitlab.com/ut_issl/s2e/s2e_core_oss/-/commit/c3ba6d93418998b91efc0a8ca57ff63e350d2636)
+  - s2e-core: [v4.0](https://github.com/ut-issl/s2e-core/releases/tag/v4.0)
 
 ## 2. Setup S2E_CORE
 
-1. Clone [S2E_CORE_OSS](https://gitlab.com/ut_issl/s2e/s2e_core_oss) repository in the same directory with `s2e_user`.
+1. Clone [s2e-core](https://github.com/ut-issl/s2e-core) repository in the same directory with `s2e_user`.
 
 2.  Execute script files to set up CSPICE and NRLMSISE-00 library.
     ```
-    └─s2e_core_oss  
+    └─s2e-core  
     └─ExtLibraries  
       └─ cspice 
       └─ nrlmsise00
@@ -30,7 +30,7 @@
 1. Make a new directory `s2e_user`. It will be a root directory of S2E_USER
     ```
     └─s2e_user  
-    └─s2e_core_oss  
+    └─s2e-core  
     └─ExtLibraries  
     ```
 
@@ -87,11 +87,11 @@
    - This is the main file of this program.
    - In this code, `User_SimBase.ini` is defined as the base file for the simulation, and an instance of the `simulation case class` named `UserCase` is created and initialized. And finally, the main routine of the class is executed.
 4.  `src/Simulation/Case`
-   - `UserCase` class is defined here. `UserCase` class inherits the `SimulationCase` base class in the `S2E_CORE_OSS`. The `SimulationCase` class has a `SimulationConfig` and `GlobalEnvironment` class. The `UserCase` class has an instance of the `spacecraft` class named as `UserSat`.
+   - `UserCase` class is defined here. `UserCase` class inherits the `SimulationCase` base class in the `S2E_CORE`. The `SimulationCase` class has a `SimulationConfig` and `GlobalEnvironment` class. The `UserCase` class has an instance of the `spacecraft` class named as `UserSat`.
 5. `src/Simulation/Spacecraft/User_sat.cpp `
-   - `UserSat` class is defined here. `UserSat` class inherits the `Spacecraft` class in the `S2E_CORE_OSS`. The `Spacecraft` base class has instances of `Dynamics`, `LocalEnvironment`, `Disturbance`, and `Structure`. And the `UserSat` class has an instance of `UserComponents`.
+   - `UserSat` class is defined here. `UserSat` class inherits the `Spacecraft` class in the `S2E_CORE`. The `Spacecraft` base class has instances of `Dynamics`, `LocalEnvironment`, `Disturbance`, and `Structure`. And the `UserSat` class has an instance of `UserComponents`.
    - In the `UserSat`'s `Update` function, these four classes are updated to simulate the spacecraft behavior.
 6. `src/Simulation/Spacecraft/User_Components.cpp`
    - The `UserComponents` class is defined here. Most users edit this code to custom the S2E for their satellite projects.
-   - Users select components they want to use from the `S2E_CORE_OSS/src/Component`.
+   - Users select components they want to use from the `s2e-core/src/Component`.
    - You can add new source codes in the `S2E_USER/Component` directory if you want to make original components.

--- a/Tutorials/HowToUseMonteCarloSimulation.md
+++ b/Tutorials/HowToUseMonteCarloSimulation.md
@@ -9,7 +9,7 @@
 - This tutorial explains how to randomly change the initial value of the angular velocity.
   - There are sample codes in `SampleCodes\MCSim`.
 - The Supported version of this document
-  - S2E_CORE_OSS: [c3ba](https://gitlab.com/ut_issl/s2e/s2e_core_oss/-/commit/c3ba6d93418998b91efc0a8ca57ff63e350d2636)
+  - s2e-core: [v4.0](https://github.com/ut-issl/s2e-core/releases/tag/v4.0)
 
 ## 2. Edit Simulation Case
 - To use the MCSim, users have to edit their `User_case.h` and `User_case.cpp`

--- a/Tutorials/HowToUseSerialPortCommunication.md
+++ b/Tutorials/HowToUseSerialPortCommunication.md
@@ -5,15 +5,15 @@
 - The HILS test can be performed by replacing satellite components with simulated components in S2E.
 - This document describes how to use serial port communication.
 - The supported version of this document
-  - S2E_CORE_OSS: [c3ba](https://gitlab.com/ut_issl/s2e/s2e_core_oss/-/commit/c3ba6d93418998b91efc0a8ca57ff63e350d2636)
+  - s2e-core: [v4.0](https://github.com/ut-issl/s2e-core/releases/tag/v4.0)
 
 ## 2. How to build files for the HILS test
 - **Currently, the HILS test is only available for Visual Studio users on Windows.**
 - Serial port operations are written in `Interface/HilsInOut/Ports/HilsUartPort.cpp` in c++/cli language.
 - When users want to execute the HILS test, complete the following steps.
-  - Edit `s2e_core_oss/CMakeLists.txt`
+  - Edit `s2e-core/CMakeLists.txt`
   - `set(USE_HILS OFF)` -> `set(USE_HILS ON)`
-  - build `s2e_core_oss`
+  - build `s2e-core`
 - **Note**: Currently, breakpoints do not work if you build c++/cli and c++ files simultaneously.
 
 ## 3. Sample codes for UART communication
@@ -21,15 +21,15 @@
   - Set loopback connection of two USB-UART converters using two USB ports of your computer.
   - Check the COM port number for each connection.
 - Software Settings
-   - `s2e_core_oss/src/Component/Abstract/ExpHils.cpp` is an example of a simulation component for serial port communication.
-   - `ExpHils` is instantiated in `s2e_core_oss/src/Simulation/Spacecraft/SampleComponents.cpp`.
+   - `s2e-core/src/Component/Abstract/ExpHils.cpp` is an example of a simulation component for serial port communication.
+   - `ExpHils` is instantiated in `s2e-core/src/Simulation/Spacecraft/SampleComponents.cpp`.
    ```c++
   // Examples of HILS
   exp_hils_responder_ = new ExpHils(clock_gen, 1, obc_, 3, 9600, hils_port_manager_, 1);
   exp_hils_sender_ = new ExpHils(clock_gen, 0, obc_, 4, 9600, hils_port_manager_, 0);
    ```
    - Edit the constructor's argument based on the COM port number checked above.
-   - For the HILS test, edit the setting of simulation speed in `s2e_core_oss/data/SampleSat/ini/SampleSimBase.ini`.
+   - For the HILS test, edit the setting of simulation speed in `s2e-core/data/SampleSat/ini/SampleSimBase.ini`.
    ```ini
    // Simulation speed. 0: as fast as possible, 1: real-time, >1: faster than real-time, <1: slower than real-time
    SimulationSpeed = 1
@@ -40,4 +40,4 @@
     - The sender component sends out a new message like `ABC`, `BCD`, ....
     - The responder component returns the message as received.
     - Data returned from the responder to the sender is output.<img src="./figs/SerialPortCommunicationConfirmation.png" alt="SerialPortCommunicationConfirmation" style="zoom: 100%;" />
-    - If the comment `Error: the specified step_sec is too small for this computer.` appears, comment out it in `s2e_core_oss/src/Environment/Global/SimTime.cpp`.
+    - If the comment `Error: the specified step_sec is too small for this computer.` appears, comment out it in `s2e-core/src/Environment/Global/SimTime.cpp`.

--- a/Tutorials/SampleCodes/s2e_user/CMakeLists.txt
+++ b/Tutorials/SampleCodes/s2e_user/CMakeLists.txt
@@ -8,7 +8,7 @@ if(WIN32)
 endif()
 
 ## set directory path
-set(S2E_CORE_DIR ../s2e_core_oss)
+set(S2E_CORE_DIR ../s2e-core)
 set(CSPICE_DIR ../ExtLibraries/cspice)
 set(NRLMSISE00_DIR ../ExtLibraries/nrlmsise00)
 set(FLIGHT_SW_DIR ../FlightSW)
@@ -57,7 +57,7 @@ if(USE_HILS AND WIN32)
   message(${WS2_32_LIB})
 endif()
 
-## include directories of S2E_CORE_OSS
+## include directories of S2E_CORE
 include_directories(${CSPICE_DIR}/include)
 include_directories(${NRLMSISE00_DIR}/src)
 include_directories(${S2E_CORE_DIR}/src/Library/math)


### PR DESCRIPTION
## Overview
Since the s2e-core is moved to Github from Gitlab, the link URL and directory name of S2E_CORE_OSS is modified to s2e-core.

## Issue
NA

## Details
- Modify all documents which refer `S2E_CORE_OSS`.

##  Validation results
No need to validate.

## Scope of influence
The behavior of sample codes will be changed.

## Supplement
NA

