### PR TITLE
Revert "TEMP: deploy test"

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -41,6 +41,7 @@ jobs:
           git commit -m "Deploy $GITHUB_SHA to gh-pages"
 
       - name: deploy
+        if: ${{ github.ref == 'refs/heads/main' }}
         working-directory: ./gh-pages
         run: |
           git push -f origin gh-pages


### PR DESCRIPTION
This reverts commit 61b7041677007c420a9c3f96e13d0d8b1f94b7c5.

## Overview
Prevent deploy to GitHub Pages on Pull Request.

## Issue
- N/A

## Details
I forgot to revert temporary commit in #4 

##  Validation results
`deploy` step in `mdbook` workflow will be skipped on this PR.

## Scope of influence
Changes in PR aren't deploy to GitHub Pages.

## Supplement
There should be another way to preview PR changes.

## Note
- If there are related Projects, tie them together.
- Assignees should be set if possible.
- Reviewers should be set if possible.
- Set `priority` label if possible.
