### PR TITLE
Fix relative path in Tutorials

### DIFF
--- a/Tutorials/HowToAddComponents.md
+++ b/Tutorials/HowToAddComponents.md
@@ -2,7 +2,7 @@
 
 ## 1.  Overview
 
-- In the [How To Make New Simulation Scenario](./Tutorials/HowToMakeNewSimulationScenario.md) tutorial, we have made an `S2E_USER` directory for our simulation scenario.
+- In the [How To Make New Simulation Scenario](./HowToMakeNewSimulationScenario.md) tutorial, we have made an `S2E_USER` directory for our simulation scenario.
 - This tutorial explains how to add components to your scenario.
 - A similar procedure is available for other components in the `S2E_CORE`.
 - The Supported version of this document

--- a/Tutorials/HowToAddControlAlgorithms.md
+++ b/Tutorials/HowToAddControlAlgorithms.md
@@ -1,7 +1,7 @@
 # How To Add Control Algorithms
 
 ## 1.  Overview
-- In the [How To Make New Components](./Tutorials/HowToMakeNewComponents.md) tutorial, we have newly made components emulating codes in [s2e-core](https://github.com/ut-issl/s2e-core) and adding the new components into our simulation scenario.
+- In the [How To Make New Components](./HowToMakeNewComponents.md) tutorial, we have newly made components emulating codes in [s2e-core](https://github.com/ut-issl/s2e-core) and adding the new components into our simulation scenario.
 - Now we can simulate the behavior of spacecraft **free motion** and emulate the behavior of sensors and actuators. 
 - This tutorial explains how to add a **Control Algorithm** into the simulation scenario. 
 - For a practical satellite project, we should implement the control algorithm as actual flight software like [C2A](https://github.com/ut-issl/c2a-core) into the S2E. However, using actual flight software is usually overdoing for use cases as research, the initial phase of satellite projects.

--- a/Tutorials/HowToMakeNewComponents.md
+++ b/Tutorials/HowToMakeNewComponents.md
@@ -2,7 +2,7 @@
 
 ## 1.  Overview
 
-- In the [How To Add Components](./Tutorials/HowToAddComponents.md) tutorial, we have added existing components to the simulation scenario.
+- In the [How To Add Components](./HowToAddComponents.md) tutorial, we have added existing components to the simulation scenario.
 - This tutorial explains how to make a new component into the S2E_USER directory.
 - **Note**: You can move the source files for the new component into the [s2e-core](https://github.com/ut-issl/s2e-core) repository if the component is useful for all S2E users.
 - The Supported version of this document
@@ -36,7 +36,7 @@
 
 3. Build `S2E_USER` and check there is no error.
 
-4. Edit `User_component.h` and `User_component.cpp` as referring [How To Add Components](./Tutorials/HowToAddComponents.md)
+4. Edit `User_component.h` and `User_component.cpp` as referring [How To Add Components](./HowToAddComponents.md)
 
    - The constructor of the `ClockSensor` requires arguments as `prescaler`, `clock_gen`, `sim_time`, and `bias_sec`.
    - `prescaler` and `bias_sec` are user setting parameters for the sensor, and you can set these value.

--- a/Tutorials/HowToMakeNewSimulationScenario.md
+++ b/Tutorials/HowToMakeNewSimulationScenario.md
@@ -2,7 +2,7 @@
 
 ## 1.  Overview
 
-- In the [Getting Started](./Tutorials/GettingStarted.md) tutorial, we can directly build and execute S2E_CORE_OSS, but for **source code sharing** and practical usage of S2E, we **strongly recommend managing S2E_CORE_OSS and S2E_USER repository separately**.
+- In the [Getting Started](./GettingStarted.md) tutorial, we can directly build and execute S2E_CORE_OSS, but for **source code sharing** and practical usage of S2E, we **strongly recommend managing S2E_CORE_OSS and S2E_USER repository separately**.
   - [s2e-core](https://github.com/ut-issl/s2e-core) repository is shared with other users. Most of the source files are in this repository. The codes are used as a library by the S2E_USER repository.
   - S2E_USER repository is an independent repository  for **each spacecraft project or research project**. This repository includes the following parts:
     - Source codes for `simulation scenario` and the `main`
@@ -80,7 +80,7 @@
      - Other initialize files are defined in this base initialize file. So you need to edit the file names in the base file when you modify the name of other initialize files.
        - When you change the name of the base file, you have to edit `S2E_USER.cpp`.
      - Details of the initialize files are described in `Specifications`.
-       - Basic files are described in [Getting Started](./Tutorials/GettingStarted.md).
+       - Basic files are described in [Getting Started](./GettingStarted.md).
    - `logs`
      - CSV log files will be outputted here. The output directory is also defined in `User_SimBase.ini`, so that you can change it.
 3. `src/S2E_USER.cpp`


### PR DESCRIPTION
## Overview
Fix relative path in Tutorials.

## Issue
- #12 

## Details
Relative path in the tutorial documents were wrong.  
And the links did not work both in Markdown and Github pages.  

##  Validation results
NA

## Scope of influence
NA

## Supplement
NA

## Note
NA
