### PR TITLE
Fix default SpaceWeather file name

### DIFF
--- a/Tutorials/SampleCodes/s2e-user/data/initialize_files/user_satellite_local_environment.ini
+++ b/Tutorials/SampleCodes/s2e-user/data/initialize_files/user_satellite_local_environment.ini
@@ -19,7 +19,7 @@ logging = ENABLE
 // Atmosphere model
 // STANDARD: Model using scale height, NRLMSISE00: NRLMSISE00 model
 model = STANDARD
-nrlmsise00_table_file = ../../../ExtLibraries/nrlmsise00/table/SpaceWeather.txt
+nrlmsise00_table_file = ../../../ExtLibraries/nrlmsise00/table/SpaceWeather-v1.2.txt
 // Whether using user-defined f10.7 and ap value
 // Ref of f10.7: https://www.swpc.noaa.gov/phenomena/f107-cm-radio-emissions
 // Ref of ap: http://wdc.kugi.kyoto-u.ac.jp/kp/kpexp-j.html


### PR DESCRIPTION
## Overview
Fix default SpaceWeather file name

## Issue
https://github.com/ut-issl/s2e-documents/pull/77

## Details
Fix default SpaceWeather file name

##  Validation results
NA

## Scope of influence
NA

## Supplement
NA

## Note
NA